### PR TITLE
Set correct index of clues using recently un-deprecated li@value

### DIFF
--- a/js/jquery.crossword.js
+++ b/js/jquery.crossword.js
@@ -191,7 +191,7 @@
 						}
 
 						// while we're in here, add clues to DOM!
-						$('#' + puzz.data[i].orientation).append('<li tabindex="1" data-position="' + i + '">' + puzz.data[i].clue + '</li>'); 
+						$('#' + puzz.data[i].orientation).append('<li tabindex="1" data-position="' + i + '" value="' + puzz.data[i].position + '">' + puzz.data[i].clue + '</li>'); 
 					}				
 					
 					// Calculate rows/cols by finding max coords of each entry, then picking the highest


### PR DESCRIPTION
I noticed that 803e201c53632e9408efd0411701dc54b326cc16 introduced a bug where both the Across and Down clues were labelled continuously (eg. 1,2,3,4...) when the actual positions are discontinuous (eg. 1,3,5...).

There is a (briefly deprecated) `value` attribute on `li` that allows setting of the indexes in a list, which this patch uses to set the actual positions of the clues. http://www.w3.org/TR/html-markup/li.html
